### PR TITLE
Add Python 3.7 and 3.8 support

### DIFF
--- a/examples/001.py
+++ b/examples/001.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 from typing import (
     Match,
     Pattern,
-    Callable,
     Callable,
     Iterable,
     ChainMap,

--- a/examples/002.py
+++ b/examples/002.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 import typing as ty, typing as ttt
 

--- a/flake8_pep585/flake_diagnostic.py
+++ b/flake8_pep585/flake_diagnostic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import NamedTuple
 
 

--- a/flake8_pep585/plugin.py
+++ b/flake8_pep585/plugin.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import ast
+import sys
 from collections.abc import Iterator
 
 from flake8_pep585 import rules
@@ -10,14 +13,59 @@ rule_classes = (
 )
 
 
+class ImportVisitor(ast.NodeVisitor):
+    """Import visitor."""
+
+    enabled: bool
+
+    def __init__(self) -> None:
+        self.enabled = False
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        if (self.enabled or ("__future__" != node.module)):
+            return
+
+        for alias in node.names:
+            if ("annotations" == alias.name):
+                self.enabled = True
+                return
+
+
 class Pep585Plugin:
     name = "flake8-pep585"
     version = "0.1.5.1"
+    activation = "auto"
+    _enabled: bool
+
+    @classmethod
+    def add_options(cls, option_manager) -> None:
+        option_manager.add_option("--pep585-activation", default="auto",
+                                  action="store", parse_from_config=True,
+                                  choices=("auto", "always", "never"), dest="pep585_activation",
+                                  help="Activate plugin, auto checks for 'from __future__ import annotations' (default: auto)")
+
+    @classmethod
+    def parse_options(cls, options) -> None:
+        if ((sys.version_info.major == 3) and (sys.version_info.minor < 7)):
+            cls.activation = "never"
+        elif ((sys.version_info.major == 3) and (sys.version_info.minor >= 9)):
+            cls.activation = "always"
+        else:
+            cls.activation = options.pep585_activation
 
     def __init__(self, tree: ast.Module) -> None:
         self._tree = tree
+        self._enabled = ("always" == self.activation)
 
     def __iter__(self) -> Iterator[FlakeDiagnostic]:
+        if ((not self._enabled) and ("never" != self.activation)):
+            import_visitor = ImportVisitor()
+            import_visitor.visit(self._tree)
+            self._enabled = import_visitor.enabled
+
+        if (not self._enabled):
+            return
+
         diagnostics: list[FlakeDiagnostic] = []
         report = diagnostics.append
         for rule_cls in rule_classes:

--- a/flake8_pep585/rules.py
+++ b/flake8_pep585/rules.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import ast
-from collections.abc import Callable
+from typing import Callable  # noqa: PEA001
 from types import MappingProxyType
 
 from flake8_pep585.flake_diagnostic import FlakeDiagnostic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/decorator-factory/flake8-pep585"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.7"
 
 [tool.poetry.dev-dependencies]
 wemake-python-styleguide = "0.16.0"


### PR DESCRIPTION
This change adds support for running on Python 3.7 and 3.8. Both of those versions support pep585 when `from __future__ import annotations` is used.

This also adds a configuration option, which when set to 'auto' (the default) will activate the plugin only when `from __future__ import annotations` is present in the file when used with 3.7 or 3.8, making it friendly for code that still uses the old style. 'auto' always enables the plugin on 3.9 and above.